### PR TITLE
Protospaceコメント機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
+gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     devise (4.8.1)
@@ -115,6 +116,11 @@ GEM
     nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (5.0.0)
     puma (3.12.6)
     racc (1.6.0)
@@ -231,6 +237,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)
+  pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
   sass-rails (~> 5)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,2 @@
+class CommentsController < ApplicationController
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,2 +1,12 @@
 class CommentsController < ApplicationController
+  def create
+    @prototype = Prototype.find(params[:id])
+    @comment = @prototype.comments.new(comment_params)
+    @comment.save
+  end
+
+  private
+  def comment_params
+    params.require(:comment).permit(:content).merge(user_id: current_user.id, prototype_id: params[:prototype.id])
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,12 +1,19 @@
 class CommentsController < ApplicationController
   def create
-    @prototype = Prototype.find(params[:id])
+    @prototype = Prototype.find(params[:prototype_id])
     @comment = @prototype.comments.new(comment_params)
-    @comment.save
+    if @comment.save
+      redirect_to prototype_path(@comment.prototype)
+    else
+      @prototype = @comment.prototype
+      @comments = @prototype.comments
+      render "prototypes/show"
+
+    end
   end
 
   private
   def comment_params
-    params.require(:comment).permit(:content).merge(user_id: current_user.id, prototype_id: params[:prototype.id])
+    params.require(:comment).permit(:content).merge(user_id: current_user.id, prototype_id: params[:prototype_id])
   end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -18,6 +18,8 @@ class PrototypesController < ApplicationController
 
   def show
     @prototype = Prototype.find(params[:id])
+    @comment = Comment.new
+    @comments = @prototype.comments.includes(:user)
   end
 
   def edit

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,2 @@
+class Comment < ApplicationRecord
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,4 +2,6 @@ class Comment < ApplicationRecord
 
   belongs_to :user
   belongs_to :prototype
+
+  validates :content, presence: true
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,2 +1,5 @@
 class Comment < ApplicationRecord
+
+  belongs_to :user
+  belongs_to :prototype
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -2,6 +2,7 @@ class Prototype < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image
+  has_many :comments
 
   validates :title, presence: true
   validates :catch_copy, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,5 @@ class User < ApplicationRecord
   validates :position, presence: true
 
   has_many :prototypes
+  has_many :comments
 end

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -9,7 +9,7 @@
       <% if @prototype.user_id == current_user.id %>
         <div class="prototype__manage">
           <%= link_to "編集する", edit_prototype_path(@prototype.id), class: :prototype__btn %>
-          <%= link_to "削除する", prototype_path, method: :delete, class: :prototype__btn %>
+          <%= link_to "削除する", prototype_path(@prototype.id), method: :delete, class: :prototype__btn %>
         </div>
         <% end %>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
@@ -32,21 +32,25 @@
       </div>
       <div class="prototype__comments">
         <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
-          <%# <%= form_with model: モデル名,local: true do |f|%>
+        <% if user_signed_in? %>
+          <%= form_with model:[@prototype, @comment],local: true do |f| %>
             <div class="field">
-              <%# <%= f.label :hoge, "コメント" %><br />
-              <%# <%= f.text_field :hoge, id:"comment_content" %>
+              <%= f.label :content, "コメント" %><br /> 
+              <%= f.text_field :content, id:"comment_content" %>
             </div>
             <div class="actions">
-              <%# <%= f.submit "送信する", class: :form__btn  %>
+              <%= f.submit "送信する", class: :form__btn %>
             </div>
-          <%# <% end %>
+          <% end %>
+        <% end %>
         <%# // ログインしているユーザーには上記を表示する %>
         <ul class="comments_lists">
           <%# 投稿に紐づくコメントを一覧する処理を記述する %>
+          <% @comments.each do |comment|%>
             <li class="comments_list">
-              <%# <%= " コメントのテキスト "%>
-              <%# <%= link_to "（ ユーザー名 ）", root_path, class: :comment_user %>
+              <%= comment.content %>
+              <%= link_to comment.user.name, root_path, class: :comment_user %>
+            <% end %>
             </li>
           <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
         </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'prototypes#index'
-  resources :prototypes, only: [:new, :create, :show, :edit, :update, :destroy]
+  resources :prototypes do
+    resources :comments, only: :create
+  end
 end

--- a/db/migrate/20221120141418_create_comments.rb
+++ b/db/migrate/20221120141418_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comments do |t|
+      t.text :content, null:false
+      t.references :prototype, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_19_102410) do
+ActiveRecord::Schema.define(version: 2022_11_20_141418) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,16 @@ ActiveRecord::Schema.define(version: 2022_11_19_102410) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "prototype_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["prototype_id"], name: "index_comments_on_prototype_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "prototypes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -60,5 +70,7 @@ ActiveRecord::Schema.define(version: 2022_11_19_102410) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "prototypes"
+  add_foreign_key "comments", "users"
   add_foreign_key "prototypes", "users"
 end


### PR DESCRIPTION
# WHAT
プロトタイプ情報へのコメント投稿機能、ユーザーの詳細ページ機能、ユーザーによってできることとできないことを制限することを実装します。

# WHY
コメント投稿時に、以下の情報を入力すること。
コメントのテキスト（text型、カラム名はcontent）
情報が欠けていると、保存をすることができない。
投稿フォームはログインしているときのみに表示される。
